### PR TITLE
fix: `emptyTag` should not override `includeWhiteChars`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -182,7 +182,7 @@
             delete obj.cdata;
           }
           s = stack[stack.length - 1];
-          if (obj[charkey].match(/^\s*$/) && !cdata) {
+          if (obj[charkey].match(/^\s*$/) && !cdata && !_this.options.includeWhiteChars) {
             emptyStr = obj[charkey];
             delete obj[charkey];
           } else {

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -132,7 +132,7 @@ class exports.Parser extends events
 
       s = stack[stack.length - 1]
       # remove the '#' key altogether if it's blank
-      if obj[charkey].match(/^\s*$/) and not cdata
+      if obj[charkey].match(/^\s*$/) and not cdata and not @options.includeWhiteChars
         emptyStr = obj[charkey]
         delete obj[charkey]
       else


### PR DESCRIPTION
Clone of fkirc/include-whitespace (Leonidas-from-XIV/node-xml2js#589).

This is required in order for .kvks files to load successfully, as they often have whitespace nodes with `\u00a0` and other whitespace values.